### PR TITLE
Exit after wp_redirect

### DIFF
--- a/classes/class.redirector.php
+++ b/classes/class.redirector.php
@@ -133,6 +133,8 @@ final class Redirector {
 
 		wp_redirect( apply_filters( 'redirector-redirect-url', $redirect_url, $redirect, $post ), apply_filters( 'redirector-status-code', $redirect['status'], $redirect ) );
 
+		exit;
+		
 	} // end template_redirect
 
 


### PR DESCRIPTION
Fixes issue with pages that should redirect getting cached by WP Super Cache (and probably others)
